### PR TITLE
fix main entry point and missing ts source

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,7 +4,6 @@ coverage/
 dist/test/
 examples/
 node_modules/
-src/
 temp/
 typings/
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "typescript-collections",
   "version": "1.1.2",
   "description": "A complete, fully tested data structure library written in TypeScript.",
-  "main": "./dist/lib/umd.js",
+  "main": "./dist/lib/index.js",
   "typings": "./dist/lib/index.d.ts",
   "scripts": {
     "install_tools": "npm install && typings install",


### PR DESCRIPTION
This changes contains the following fixes
- use `index.js` instead of the bundled version `umd.js`, this prevents webpack from spitting out errors due to rebundling an already bundled library
- ship `src/` folder in npm package - prevents webpack from spitting out errors due to missing `*.ts` library
